### PR TITLE
feat: use git commit id to generate image tag for deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
             steps {
                 script {
                     docker.withRegistry('https://registry-1.docker.io/', dockerCredentialsId) {
-                        apiImage.push('latest')
+                        apiImage.push()
                     }
                 }
             }
@@ -88,7 +88,7 @@ pipeline {
 
                             echo "Next release is ${nextCandidate}"
 
-                            sh "kubectl apply -f k8s/${nextCandidate}-deployment.yaml"
+                            sh "tagid=${shortCommit} envsubst < k8s/${nextCandidate}-deployment.yaml | kubectl apply -f -"
 
                             def status = null
                             def remaining = 5
@@ -155,7 +155,11 @@ pipeline {
         }
 
         success {
-            echo "tag the image as latest"
+            script {
+                docker.withRegistry('https://registry-1.docker.io/', dockerCredentialsId) {
+                    apiImage.push('latest')
+                }
+            }
         }
 
         cleanup {

--- a/k8s/blue-deployment.yaml
+++ b/k8s/blue-deployment.yaml
@@ -19,6 +19,6 @@ spec:
     spec:
       containers:
       - name: capstone-api
-        image: mcastellin/udacity-capstone-api:latest
+        image: mcastellin/udacity-capstone-api:${tagid}
         ports:
         - containerPort: 80

--- a/k8s/green-deployment.yaml
+++ b/k8s/green-deployment.yaml
@@ -19,6 +19,6 @@ spec:
     spec:
       containers:
       - name: capstone-api
-        image: mcastellin/udacity-capstone-api:latest
+        image: mcastellin/udacity-capstone-api:${tagid}
         ports:
         - containerPort: 80


### PR DESCRIPTION
When generating a new release, we use the tag to identify a unique image from Kubernetes so the deployment does not happen automatically.

Upon successful release, the image is tagged as latest.