### PR TITLE
feat: add liveness probe to container deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
 
         success {
             script {
-                if(isRelease) {
+                if(isRelease == true) {
                     docker.withRegistry('https://registry-1.docker.io/', dockerCredentialsId) {
                         apiImage.push('latest')
                     }

--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,10 @@ def home():
     html = "<h3>Auto scaling application test</h3>"
     return html.format(format)
 
+@app.route("/health")
+def health():
+    html = "Application is healthy!"
+    return html.format(format)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080, debug=True)

--- a/k8s/blue-deployment.yaml
+++ b/k8s/blue-deployment.yaml
@@ -22,3 +22,11 @@ spec:
         image: mcastellin/udacity-capstone-api:${tagid}
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 3
+          successThreshold: 2

--- a/k8s/green-deployment.yaml
+++ b/k8s/green-deployment.yaml
@@ -22,3 +22,11 @@ spec:
         image: mcastellin/udacity-capstone-api:${tagid}
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 3
+          successThreshold: 2


### PR DESCRIPTION
Adding a liveness probe for the application to check for api `/health`